### PR TITLE
Add wow_vanilla_dbc and wow_world_messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,7 @@ This resource will act like a hub to share ideas and experiment with alternative
 
 - [wow-srp](https://github.com/gtker/wow_srp): wow's flavour of SRP-6 authentication
 - [wow_login_messages](https://github.com/gtker/wow_messages): datastructures for the wow login server
+- [wow_world_messages](https://github.com/gtker/wow_messages): message definitions and types for wow world server
 - [wow_message_parser](https://github.com/gtker/wow_messages/tree/main/wow_message_parser): a pest-based parser for wow packets
 - [wowm](https://gtker.com/wow_messages/): a DSL for the world of warcraft protocol, aiming to cover client / server for versions 1.x, 2.x, and 3.x
+- [wow_vanilla_dbc](https://github.com/gtker/wow_vanilla_dbc): library for reading 1.12 DBC files


### PR DESCRIPTION
Thought it was worthwhile to link to the `wow_world_messages` crate as well, even though it's technically the same repo as `wow_login_messages` and `wow_message_parser`, just to highlight that it exists.