### PR TITLE
Change wow_vanilla_dbc to wow_dbc, add wow_vanilla_server

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This resource will act like a hub to share ideas and experiment with alternative
 
 - [wrath-rs](https://github.com/Victov/wrath-rs): the most complete implementation, with movement in the world 
 - [azerust](https://github.com/arlyon/azerust): an experiment into a modular high-tech server platform with interfaces over graphql and [tokio-console](https://github.com/tokio-rs/console)
+- [wow_vanilla_server](https://github.com/gtker/wow_vanilla_server): experimental 1.12 server with no external dependencies other than `cargo run`.
 
 ## Libraries
 
@@ -17,4 +18,4 @@ This resource will act like a hub to share ideas and experiment with alternative
 - [wow_world_messages](https://github.com/gtker/wow_messages): message definitions and types for wow world server
 - [wow_message_parser](https://github.com/gtker/wow_messages/tree/main/wow_message_parser): a pest-based parser for wow packets
 - [wowm](https://gtker.com/wow_messages/): a DSL for the world of warcraft protocol, aiming to cover client / server for versions 1.x, 2.x, and 3.x
-- [wow_vanilla_dbc](https://github.com/gtker/wow_vanilla_dbc): library for reading 1.12 DBC files
+- [wow_dbc](https://github.com/gtker/wow_dbc): library for reading 1.12, 2.4.3, and 3.3.5 DBC files


### PR DESCRIPTION
`wow_vanilla_dbc` has been deprecated in favor of `wow_dbc`.